### PR TITLE
fix scrollbar design on chromium

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -5,6 +5,8 @@
     --color-surface: #333;
     --color-danger: #fa2b58;
     --appended-item-size: 2.5rem;
+
+    color-scheme: dark;
 }
 
 body {
@@ -35,6 +37,7 @@ form > * {
 
 fieldset {
     border-radius: 8px;
+    border-color: white;
 }
 
 label {


### PR DESCRIPTION
sets `color-scheme` to `dark` so the browser chooses a dark background for the scrollbar which looks better