### PR TITLE
fix(cspell): ensure pre-commit hook passes when only ignored files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,10 @@
           enable = true;
           args = ["--number"];
         };
-        cspell.enable = true;
+        cspell = {
+          enable = true;
+          args = ["--no-must-find-files"];
+        };
 
         # C/C++ & Build-Systems
         clang-format = {


### PR DESCRIPTION
added an argument passed to cspell so it does not fail when no files are found